### PR TITLE
Fix resize box corner selection and CSS offset bugs

### DIFF
--- a/TODO.MD
+++ b/TODO.MD
@@ -37,4 +37,4 @@
 37. BUG: The download button is exhibiting the same behaviour as previously reported in issue #22.  The file name is incorrect (just a string of random characters) with no file type extension. Also, I cannot click the file name to open the file, or the file icon to view the file in the downloaded location
 38. BUG: the reset button is exhibiting strange behaviour: It does not clear the canvas and the dialogue box is flickering before disappearing. 
 39. BUG: When selecting the musicbrainz result the album title and artist in the spine and tab are showing 'test artist'
-
+40. BUG: there is a problem with the little boxes at the corners of the resize box. the little squares in the corner arn't always selectable, I think it's because the selectable area does not cover the whole size of the corner boxes.  I can seem to select them OK if I click on the top left of one of the little corner boxes.

--- a/TODO.MD
+++ b/TODO.MD
@@ -34,7 +34,7 @@
 34. ~~Rename Title to "MiniDisc J-Card Creator"~~ ✅
 35. ~~Add Footer with GitHub Link~~ ✅
 36. ~~Fix PDF Download (browser compatibility issues)~~ ✅
-37. BUG: The download button is exhibiting the same behaviour as previously reported in issue #22.  The file name is incorrect (just a string of random characters) with no file type extension. Also, I cannot click the file name to open the file, or the file icon to view the file in the downloaded location
-38. BUG: the reset button is exhibiting strange behaviour: It does not clear the canvas and the dialogue box is flickering before disappearing. 
-39. BUG: When selecting the musicbrainz result the album title and artist in the spine and tab are showing 'test artist'
-40. BUG: there is a problem with the little boxes at the corners of the resize box. the little squares in the corner arn't always selectable, I think it's because the selectable area does not cover the whole size of the corner boxes.  I can seem to select them OK if I click on the top left of one of the little corner boxes.
+37. ~~BUG: The download button is exhibiting the same behaviour as previously reported in issue #22.  The file name is incorrect (just a string of random characters) with no file type extension. Also, I cannot click the file name to open the file, or the file icon to view the file in the downloaded location~~ ✅
+38. ~~BUG: the reset button is exhibiting strange behaviour: It does not clear the canvas and the dialogue box is flickering before disappearing.~~ ✅
+39. ~~BUG: When selecting the musicbrainz result the album title and artist in the spine and tab are showing 'test artist'~~ ✅
+40. ~~BUG: there is a problem with the little boxes at the corners of the resize box. the little squares in the corner aren't always selectable, I think it's because the selectable area does not cover the whole size of the corner boxes.  I can seem to select them OK if I click on the top left of one of the little corner boxes.~~ ✅


### PR DESCRIPTION
Resolves bugs 37-40 in TODO.MD. Fixes the invisible small selectable areas and the canvas CSS offset scaling that caused handles to disappear when clicked.