### PR TITLE
Fix PDF Download Reference Error

### DIFF
--- a/web/src/Editor.jsx
+++ b/web/src/Editor.jsx
@@ -467,8 +467,8 @@ function Editor(props) {
         doc.line(insideFoldX, y + totalH + co, insideFoldX, y + totalH + co + foldMarkLength);
 
         // Fallback if safeName returns empty string or just underscores
-        const finalArtist = safeName(artistName) || 'Artist';
-        const finalAlbum = safeName(albumTitle) || 'Album';
+        const finalArtist = safeName(getArtistName()) || 'Artist';
+        const finalAlbum = safeName(getAlbumTitle()) || 'Album';
 
         const filename = `${finalArtist}-${finalAlbum}-jcard.pdf`;
         console.log("Saving PDF with explicit Blob and file-saver:", filename);


### PR DESCRIPTION
Fixes a ReferenceError where artistName and albumTitle variables were used directly instead of the new getArtistName() and getAlbumTitle() getter methods, which was breaking the 'Download PDF' button.