### PR TITLE
Fix MusicBrainz Search API Rejection

### DIFF
--- a/internal/musicbrainz/client.go
+++ b/internal/musicbrainz/client.go
@@ -11,7 +11,7 @@ import (
 const (
 	BaseURL = "https://musicbrainz.org/ws/2"
 	// UserAgent is required by MusicBrainz API
-	UserAgent = "MiniDiscCoverCreator/1.0.0 ( contact@example.com )"
+	UserAgent = "MiniDiscCoverCreator/1.0.0 ( https://github.com/batgranny/md-cover-creator )"
 )
 
 type Client struct {


### PR DESCRIPTION
Updates the MusicBrainz API User-Agent from a generic string to the repository URL to prevent connection resets by Hetzner/MusicBrainz abuse filters.